### PR TITLE
fix: remove functions property from vercel.json to resolve build conf…

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -12,7 +12,9 @@
             "src": "backend/api/index.ts",
             "use": "@vercel/node",
             "config": {
-                "maxLambdaSize": "50mb"
+                "maxLambdaSize": "50mb",
+                "maxDuration": 30,
+                "memory": 1024
             }
         }
     ],
@@ -37,12 +39,6 @@
             "dest": "/frontend/dist/index.html"
         }
     ],
-    "functions": {
-        "backend/api/index.ts": {
-            "maxDuration": 30,
-            "memory": 1024
-        }
-    },
     "headers": [
         {
             "source": "/api/(.*)",


### PR DESCRIPTION
…lict

- Remove 'functions' property that conflicts with 'builds' property
- Move maxDuration and memory config into builds config
- Vercel requires either 'builds' OR 'functions', not both
- Configuration now fully compatible with Vercel deployment